### PR TITLE
Fix rails autoloading issue

### DIFF
--- a/lib/restrict/rails/railtie.rb
+++ b/lib/restrict/rails/railtie.rb
@@ -2,7 +2,9 @@ module Restrict
   module Rails
     class Railtie < ::Rails::Railtie
       initializer 'restrict.add_controller_extension' do
-        ActionController::Base.send :include, Restrict::Rails::Controller
+        ActiveSupport.on_load(:action_controller_base) do
+          ActionController::Base.include Restrict::Rails::Controller
+        end
       end
     end
   end


### PR DESCRIPTION
See https://github.com/rails/rails/issues/36546 for details.

This fixes the following warning:

```
DEPRECATION WARNING: Initialization autoloaded the constants ApplicationHelper, [... many other constants ...]

Being able to do this is deprecated. Autoloading during initialization is going
to be an error condition in future versions of Rails.
```